### PR TITLE
This enforces the host enrollment

### DIFF
--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -52,6 +52,7 @@ class easy_ipa::install::client {
   ${client_install_cmd_opts_mkhomedir} \
   ${client_install_cmd_opts_fixed_primary} \
   ${client_install_cmd_opts_no_ntp} \
+  --force-join \
   --unattended"
 
   exec { "client_install_${::fqdn}":


### PR DESCRIPTION
so that it will succeed even if the host entry already exists